### PR TITLE
feat(album): add AlbumAdapter and AlbumFragment classes

### DIFF
--- a/app/src/main/java/co/edu/uniandes/vinilos/ui/album/AlbumAdapter.kt
+++ b/app/src/main/java/co/edu/uniandes/vinilos/ui/album/AlbumAdapter.kt
@@ -1,0 +1,108 @@
+package co.edu.uniandes.vinilotunes.ui.album
+
+import android.annotation.SuppressLint
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.recyclerview.widget.RecyclerView
+import co.edu.uniandes.vinilotunes.R
+import co.edu.uniandes.vinilotunes.data.model.Album
+import co.edu.uniandes.vinilotunes.databinding.ItemAlbumLayoutBinding
+import com.bumptech.glide.Glide
+
+/**
+ * Adapter para la vista de lista de álbumes.
+ * Este adapter se utiliza para vincular datos de álbumes a la vista de lista y manejar eventos de selección.
+ * @property onAlbumSelected Callback para manejar eventos de selección de álbumes.
+ * @property albumList Lista de álbumes que se mostrarán en la vista de lista.
+ */
+class AlbumAdapter : RecyclerView.Adapter<AlbumAdapter.AlbumHolder>() {
+
+    var onAlbumSelected: ((id: Int) -> Unit)? = null // Esta linea se encarga de inicializar el manejador de eventos de selección de un álbum.
+    // En caso de que no se seleccione un álbum, no se devuelve nada. Si se selecciona un álbum, se devuelve el id del álbum seleccionado.
+
+
+    // Este método se encarga de actualizar la lista de álbumes. Se llama cada vez que se actualiza la lista de álbumes.
+    var albumList: List<Album> = listOf()  // Esta linea se encarga de inicializar la lista de álbumes.
+        @SuppressLint("NotifyDataSetChanged") // Esta linea se encarga de suprimir el lint warning de NotifyDataSetChanged.
+        set(value) { // Este método se encarga de actualizar la lista de álbumes.
+            field = value // Esta linea se encarga de asignar la lista de álbumes.
+            notifyDataSetChanged() // Esta linea se encarga de notificar que los datos han cambiado.
+        }
+
+    /**
+     * Este método se encarga de manejar el evento de selección de un álbum.
+     * @param position La posición del álbum que va a ser seleccionado.
+     */
+    fun onClickAlbum(position: Int) {
+        onAlbumSelected?.invoke(albumList[position].id!!) // Esta linea se encarga de invocar un album cuando se selecciona en la lista de álbumes.
+    }
+
+    /**
+     * Este método se encarga de crear un nuevo ViewHolder.
+     * Un ViewHolder describe una vista de un ítem y metadatos sobre su posición dentro del RecyclerView.
+     * Este método se llama cuando el RecyclerView necesita un nuevo ViewHolder para representar un ítem.
+     * @param parent El ViewGroup en el que se añadirá la nueva vista.
+     * @param viewType El tipo de vista de la nueva vista.
+     * @return Devuelve un nuevo AlbumHolder que contiene una vista de la nueva vista.
+     */
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AlbumHolder {
+        val view = LayoutInflater.from(parent.context)  // Esta linea se encarga de obtener el contexto de la vista padre.
+            .inflate(R.layout.item_album_layout, parent, false) // Infla el diseño de la vista del ítem desde el archivo item_album_layout.xml
+        return AlbumHolder(view) // Devuelve un nuevo AlbumHolder que contiene una vista de la nueva vista.
+
+       // Un ViewHolder describe una vista de un ítem y metadatos sobre su posición dentro del
+       // RecyclerView vs AlbumHolder que describe una vista de un ítem y metadatos sobre su
+       // posición dentro del RecyclerView y contiene un método bind.
+
+    }
+
+    /**
+     * Este método se encarga de actualizar el contenido de un ViewHolder.
+     * Utiliza el parámetro position para indicar la posición del ítem dentro del conjunto de datos del adaptador.
+     * @param holder El ViewHolder que debe actualizarse.
+     * @param position La posición del ítem dentro del conjunto de datos del adaptador.
+     */
+    override fun onBindViewHolder(holder: AlbumHolder, position: Int) {
+        holder.bind(albumList[position], position, this) // Este método se encarga de actualizar el contenido de un ViewHolder.
+    }
+
+    /**
+     * Este método se encarga de obtener el número de ítems en el conjunto de datos del adaptador.
+     * @return Devuelve el número de ítems en el conjunto de datos del adaptador.
+     */
+    override fun getItemCount() = albumList.size
+
+    /**
+     * Esta clase representa un ViewHolder que contiene una vista de un ítem.
+     * Un ViewHolder describe una vista de un ítem y metadatos sobre su posición dentro del RecyclerView.
+     * @param view La vista de un ítem.
+     */
+    class AlbumHolder(view: View): RecyclerView.ViewHolder(view) {
+
+        // Este valor representa el enlace de datos de la vista de un ítem.
+        private val binding: ItemAlbumLayoutBinding = DataBindingUtil.bind(view)!!
+
+        /**
+         * Este método se encarga de enlazar los datos de un álbum con la vista de un ítem.
+         * @param album El álbum que se va a enlazar con la vista de un ítem.
+         * @param position La posición del álbum que se va a enlazar con la vista de un ítem.
+         * @param albumAdapter  El adaptador de álbumes que gestiona la vista.
+         */
+        fun bind(album: Album, position: Int, albumAdapter: AlbumAdapter){
+            binding.album = album
+            binding.position = position
+            binding.albumAdapter = albumAdapter
+
+            // Esta linea se encarga de cargar la imagen del álbum en la vista de un ítem,
+            // por medio de album.cover que contiene la URL de la imagen.
+            // Glide es una librería de Android que se utiliza para cargar imágenes desde una URL.
+            Glide.with(binding.root.context)// Esta linea se encarga de obtener el contexto de la vista padre.
+                .load(album.cover) // Esta linea se encarga de cargar la imagen del álbum
+                .into(binding.albumImage) // Esta linea se encarga de cargar la imagen del álbum en la vista de un ítem.
+        }
+
+    }
+
+}

--- a/app/src/main/java/co/edu/uniandes/vinilos/ui/album/AlbumFragment.kt
+++ b/app/src/main/java/co/edu/uniandes/vinilos/ui/album/AlbumFragment.kt
@@ -1,0 +1,82 @@
+package co.edu.uniandes.vinilotunes.ui.album
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import co.edu.uniandes.vinilotunes.databinding.FragmentAlbumBinding
+
+/**
+ * Clase que representa el Fragmento de Album.
+ * Esta clase es la encargada de manejar la vista de álbumes.
+ * @return Devuelve una vista de álbum.
+ */
+class AlbumFragment : Fragment() {
+
+    // Esta linea es la encargada de hacer el binding con el ViewModel.
+    // Un ViewModel es una clase  que se encarga de manejar la lógica de negocio de la vista.
+    private var _binding: FragmentAlbumBinding? = null // Binding para acceder a los componentes de la vista. Devuelve una vista de álbum o null si no existe.
+
+    // Binding para acceder a los componentes de la vista. get es un método que devuelve una vista de álbum o null si no existe.
+    private val binding get() = _binding!!
+
+    // Esta linea devuelve una instancia del ViewModel de álbum. viewModels() es un método que devuelve una instancia del ViewModel de álbum.
+    private val albumViewModel: AlbumViewModel by viewModels()
+
+
+
+    /**
+     * Método que se llama cuando el fragmento ha creado su vista.
+     * @param inflater El LayoutInflater que se puede utilizar para inflar cualquier vista.
+     * @param container Si no es nulo, este es el padre al que se deben adjuntar las vistas.
+     * @param savedInstanceState Si no es nulo, este fragmento se está reconstruyendo a partir de
+     * un estado guardado anterior como se indica aquí.
+     * @return Devuelve la vista raíz del fragmento, es decir, la vista raíz de la jerarquía de
+     * vistas del fragmento.
+     */
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        // Infla el diseño de la vista del fragmento desde el archivo fragment_album.xml
+        // y lo asigna como la vista de este fragmento.
+        _binding = FragmentAlbumBinding.inflate(layoutInflater)
+
+        // Obtiene una referencia a la vista raíz y la devuelve.
+        val root: View = binding.root
+
+        // Crea un adaptador para la lista de álbumes.
+        val adapter = AlbumAdapter()
+
+        // Asigna el adaptador a la lista de álbumes.
+        binding.rvAlbums.adapter = adapter
+
+        // Observa el evento de selección de un álbum.
+        albumViewModel.listAlbums.observe(viewLifecycleOwner) {
+            adapter.albumList = it // Actualiza la lista de álbumes.
+        }
+
+        return root // Devuelve la vista raíz.
+    }
+
+    /**
+     * Método que se llama cuando el fragmento se ha hecho visible.
+     */
+    override fun onResume() {
+        super.onResume()
+        albumViewModel.getAlbums()
+    }
+
+    /**
+     * Método que se llama cuando el fragmento se destruye.
+     */
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+
+
+}

--- a/app/src/main/java/co/edu/uniandes/vinilos/ui/album/AlbumViewModel.kt
+++ b/app/src/main/java/co/edu/uniandes/vinilos/ui/album/AlbumViewModel.kt
@@ -1,0 +1,50 @@
+package co.edu.uniandes.vinilotunes.ui.album
+
+import android.app.Application
+import android.util.Log
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
+import co.edu.uniandes.vinilotunes.data.model.Album
+import co.edu.uniandes.vinilotunes.data.repository.AlbumRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+/**
+ * Esta clase es la encargada de manejar la comunicación con el servidor para obtener los datos de los álbumes.
+ * @property application La aplicación que se está ejecutando.
+ */
+class AlbumViewModel(application: Application) : AndroidViewModel(application) {
+
+    // Utilizamos MutableLiveData para poder cambiar su valor dinámicamente. En este caso, el valor de la variable es una lista de álbumes.
+    val listAlbums = MutableLiveData<List<Album>>()
+
+    // Utilizamos MutableLiveData para poder cambiar su valor dinámicamente. En este caso, el valor de la variable es un álbum.
+    val album = MutableLiveData<Album>()
+
+    // Variable que almacena el repositorio de álbumes. El repositorio es el encargado de manejar la comunicación con el servidor.
+    private val albumsRepository = AlbumRepository(application)
+
+    // Variable que almacena el texto que se muestra en la vista. En este caso, el texto es "This is album Fragment".
+    private val _text = MutableLiveData<String>().apply {
+        value = "This is album Fragment"
+    }
+
+    // LiveData es una clase que se utiliza para notificar a las vistas cuando los datos cambian. En este caso, el valor de la variable es un texto.
+    val text: LiveData<String> = _text
+
+
+    /**
+     * Función que obtiene todos los álbumes. Esta función se ejecuta en un hilo secundario.
+     */
+    fun getAlbums() {
+        try {
+            viewModelScope.launch(Dispatchers.IO) {// Corutina que se ejecuta en un hilo secundario.
+                listAlbums.postValue(albumsRepository.getAllAlbums()) // Se obtienen los álbumes y se actualiza el valor de la variable.
+            }
+        } catch (e: Exception) {
+            Log.e("Error", e.message ?: "Failure service")
+        }
+    }
+}


### PR DESCRIPTION
The AlbumAdapter class is responsible for binding album data to the list view and handling album selection events. It includes methods for updating the album list and handling album selection.

The AlbumFragment class represents the fragment for displaying albums. It includes a ViewModel for managing the business logic of the view. The fragment inflates the layout file, sets up the adapter for the album list, and observes changes in the album list data.

The AlbumViewModel class handles communication with the server to retrieve album data. It includes methods for getting all albums and updating the album list LiveData. The ViewModel is responsible for retrieving the data on a background thread using coroutines.

The changes were made to implement the functionality of displaying albums and handling album selection events in the application.